### PR TITLE
Situodys

### DIFF
--- a/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryCustom.java
@@ -1,9 +1,13 @@
 package com.sanhak.backend.domain.post.repository;
 
 import com.sanhak.backend.domain.post.Post;
+import com.sanhak.backend.global.PageRequestDTO;
+import org.springframework.data.domain.PageImpl;
 
 import java.util.Optional;
 
 public interface PostRepositoryCustom {
     Optional<Post> findPostDetailByPostId(Long id);
+
+    PageImpl<Object[]> getPostList(PageRequestDTO pageRequestDTO);
 }

--- a/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryImpl.java
@@ -1,10 +1,25 @@
 package com.sanhak.backend.domain.post.repository;
 
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sanhak.backend.domain.post.Post;
+import com.sanhak.backend.global.PageRequestDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
 import static com.sanhak.backend.domain.comment.QComment.comment;
 import static com.sanhak.backend.domain.post.QPost.post;
 
@@ -26,5 +41,101 @@ public class PostRepositoryImpl implements PostRepositoryCustom{
                 .fetchOne();
 
         return Optional.ofNullable(result);
+    }
+
+    @Override
+    public PageImpl<Object[]> getPostList(PageRequestDTO pageRequestDTO) {
+
+        List<Long> ids;
+        int totalCount= pageRequestDTO.getTotalCount();
+
+        if (totalCount == -1) {
+            totalCount = getTotalListCount(pageRequestDTO);
+        }
+
+        List<OrderSpecifier> orders = getOrderSpecifier(pageRequestDTO.getSort());
+        ids = getPostListIds(pageRequestDTO,orders);
+        if (ids.isEmpty()) {
+            return null;
+        }
+
+
+        List<Tuple>  result = jpaQueryFactory.select(post.id,post.title,post.content, comment.count())
+                .from(post)
+                .leftJoin(comment).on(comment.post.eq(post))
+                .where(
+                        post.id.in(ids)
+                )
+                .orderBy(orders.stream().toArray(OrderSpecifier[]::new))
+                .groupBy(post)
+                .fetch();
+
+        return new PageImpl<Object[]>(
+                result.stream()
+                        .map(tuple -> tuple.toArray())
+                        .collect(Collectors.toList()), pageRequestDTO.getPageable(), totalCount
+        );
+
+
+    }
+
+    private List<OrderSpecifier> getOrderSpecifier(Sort sort) {
+        List<OrderSpecifier> orders = new ArrayList<>();
+
+        sort.stream().forEach(order -> {
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+            String prop = order.getProperty();
+            PathBuilder orderExpression = new PathBuilder(Post.class, "post");
+            orders.add(new OrderSpecifier(direction, orderExpression.get(prop)));
+        });
+        return orders;
+    }
+
+    private int getTotalListCount(PageRequestDTO pageRequestDTO) {
+        String searchType = pageRequestDTO.getSearchType();
+        String searchKeyword = pageRequestDTO.getSearchKeyword();
+
+
+        return jpaQueryFactory.select(post.id)
+                .from(post)
+                .where(
+                        post.id.gt(0L)
+                        ,isTitleContainsKeyword(searchType, searchKeyword)
+                        ,isContentContainsKeyword(searchType, searchKeyword)
+                )
+                .fetch().size();
+    }
+
+    private List<Long> getPostListIds(PageRequestDTO pageRequestDTO, List<OrderSpecifier> orders) {
+        String searchType = pageRequestDTO.getSearchType();
+        String searchKeyword = pageRequestDTO.getSearchKeyword();
+
+
+        return jpaQueryFactory.select(post.id)
+                .from(post)
+                .where(
+                        post.id.gt(0L)
+                        , isTitleContainsKeyword(searchType, searchKeyword)
+                        , isContentContainsKeyword(searchType, searchKeyword)
+                )
+                .offset(pageRequestDTO.getOffset())
+                .limit(pageRequestDTO.getSize())
+                .orderBy(orders.stream().toArray(OrderSpecifier[]::new))
+                .fetch();
+
+    }
+
+    private BooleanExpression isTitleContainsKeyword(String searchType,String searchKeyword) {
+        if (searchType==null || !searchType.contains("t")) {
+            return null;
+        }
+        return post.title.containsIgnoreCase(searchKeyword);
+    }
+
+    private BooleanExpression isContentContainsKeyword(String searchType,String searchKeyword) {
+        if (searchType==null || !searchType.contains("c")) {
+            return null;
+        }
+        return post.content.containsIgnoreCase(searchKeyword);
     }
 }

--- a/src/main/java/com/sanhak/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/sanhak/backend/domain/post/service/PostService.java
@@ -2,6 +2,7 @@ package com.sanhak.backend.domain.post.service;
 
 import com.sanhak.backend.domain.post.Post;
 import com.sanhak.backend.domain.post.dto.PostDTO;
+import com.sanhak.backend.domain.post.dto.PostDetailDTO;
 import com.sanhak.backend.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -23,11 +24,11 @@ public class PostService {
                 .map(post -> modelMapper.map(post, PostDTO.class));
     }
 
-    public PostDTO findById(Long id) {
+    public PostDetailDTO findPostDetailByPostId(Long id) {
         Post post = postRepository
-                .findByPostId(id)
+                .findPostDetailByPostId(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 post가 없습니다."));
-        return modelMapper.map(post, PostDTO.class);
+        return modelMapper.map(post, PostDetailDTO.class);
     }
 
     public void removeById(Long id) {

--- a/src/main/java/com/sanhak/backend/global/PageRequestDTO.java
+++ b/src/main/java/com/sanhak/backend/global/PageRequestDTO.java
@@ -1,0 +1,20 @@
+package com.sanhak.backend.global;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@AllArgsConstructor
+@Data
+public class PageRequestDTO {
+    private int page;
+    private int size;
+    
+    private String searchType;
+    private String searchKeyword;
+
+    //검색에서 마지막 결과의 id
+    private Long lastId;
+    private int totalSize;
+}

--- a/src/main/java/com/sanhak/backend/global/PageRequestDTO.java
+++ b/src/main/java/com/sanhak/backend/global/PageRequestDTO.java
@@ -3,18 +3,29 @@ package com.sanhak.backend.global;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 @Builder
 @AllArgsConstructor
 @Data
 public class PageRequestDTO {
-    private int page;
-    private int size;
+    private Pageable pageable;
     
     private String searchType;
     private String searchKeyword;
 
-    //검색에서 마지막 결과의 id
-    private Long lastId;
-    private int totalSize;
+    private int totalCount;
+
+    public Sort getSort() {
+        return pageable.getSort();
+    }
+
+    public int getSize(){
+        return pageable.getPageSize();
+    }
+
+    public long getOffset() {
+        return pageable.getOffset();
+    }
 }

--- a/src/main/java/com/sanhak/backend/global/PageResponseDTO.java
+++ b/src/main/java/com/sanhak/backend/global/PageResponseDTO.java
@@ -1,0 +1,50 @@
+package com.sanhak.backend.global;
+
+import lombok.Data;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Data
+public class PageResponseDTO<DTO> {
+
+    private List<DTO> dtoList;
+
+    private int totalPage;
+    private int page;
+    private int size;
+
+    private int start,end;
+
+    private boolean prev,next;
+
+    private List<Integer> pageList;
+
+    public PageResponseDTO(Page<DTO> result) {
+        dtoList = result.getContent();
+        totalPage = result.getTotalPages();
+        makePageList(result.getPageable());
+    }
+
+    private void makePageList(Pageable pageable) {
+        this.page=pageable.getPageNumber()+1;
+        this.size = pageable.getPageSize();
+
+        int tempEnd=(int)(Math.ceil(page/10.0))*10;
+
+        start= tempEnd-9;
+
+        prev=start>1;
+
+        end=totalPage>tempEnd ? tempEnd : totalPage;
+
+        next=totalPage>tempEnd;
+
+        pageList= IntStream.rangeClosed(start,end).boxed().collect(Collectors.toList());
+    }
+}
+

--- a/src/test/java/com/sanhak/backend/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/sanhak/backend/domain/post/repository/PostRepositoryTest.java
@@ -3,6 +3,7 @@ package com.sanhak.backend.domain.post.repository;
 import com.sanhak.backend.domain.comment.Comment;
 import com.sanhak.backend.domain.comment.repository.CommentRepository;
 import com.sanhak.backend.domain.post.Post;
+import com.sanhak.backend.global.PageRequestDTO;
 import com.sanhak.backend.global.QuerydslConfig;
 import org.aspectj.lang.annotation.Before;
 import org.assertj.core.api.Assertions;
@@ -13,15 +14,20 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 
 
 import javax.persistence.EntityManager;
 import java.io.InputStream;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -40,28 +46,36 @@ class PostRepositoryTest {
 
     @BeforeAll
     public void init(){
-        Post post = Post.builder()
-                .id(1L)
-                .cafeName("cafe1")
-                .categoryName("category1")
-                .title("title1")
-                .author("author1")
-                .content("content1")
-                .link("link1")
-                .similarity(0.1)
-                .registerAt(LocalDateTime.of(2022, 1, 1, 11, 11))
-                .build();
+        generatePosts(1,25);
+        generateComments(1L,1,5);
+    }
 
-        postRepository.save(post);
-
-        IntStream.rangeClosed(1,5)
+    private void generateComments(Long PostId, int start, int end) {
+        IntStream.rangeClosed(start,end)
                 .forEach(i->{
                     Comment comment = Comment.builder()
                             .content("content.." + i)
-                            .post(Post.builder().id(1L).build())
+                            .post(Post.builder().id(PostId).build())
                             .build();
                     commentRepository.save(comment);
                 });
+    }
+
+    private void generatePosts(int start, int end) {
+        LongStream.rangeClosed(start,end)
+                        .forEach(id->{
+                            Post post = Post.builder()
+                                    .cafeName("cafe" + id)
+                                    .categoryName("category" + id)
+                                    .title("title" + id)
+                                    .author("author" + id)
+                                    .content("content" + id)
+                                    .link("link" + id)
+                                    .similarity(0.1)
+                                    .registerAt(LocalDateTime.of(2022, 1, 1, 11, 11))
+                                    .build();
+                            postRepository.save(post);
+                        });
     }
 
     @Test
@@ -92,5 +106,49 @@ class PostRepositoryTest {
         Optional<Post> result = postRepository.findPostDetailByPostId(postId);
         assertThat(result.isPresent()).isEqualTo(false);
         //then
+    }
+
+    @Test
+    @DisplayName("기본 페이징 처리된 Post list 반환")
+    public void getPostList_test() throws Exception{
+        //give
+        PageRequestDTO pageRequestDTO = PageRequestDTO.builder()
+                .pageable(PageRequest.of(0, 10, Sort.by("id")))
+                .searchType(null)
+                .searchKeyword(null)
+                .totalCount(-1)
+                .build();
+
+
+        //when
+        PageImpl<Object[]> result = postRepository.getPostList(pageRequestDTO);
+
+        //then
+        assertThat(result.getTotalElements()).isEqualTo(25);
+        assertThat(result.getTotalPages()).isEqualTo(3);
+        for (Object[] objects : result) {
+            System.out.println(Arrays.toString(objects));
+        }
+    }
+
+    @Test
+    @DisplayName("제목에 1이 들어간 Post list 반환")
+    public void getPostList_test2() throws Exception{
+        PageRequestDTO pageRequestDTO = PageRequestDTO.builder()
+                .pageable(PageRequest.of(0, 10, Sort.by("id")))
+                .searchType("t")
+                .searchKeyword("1")
+                .totalCount(-1)
+                .build();
+
+        //when
+        PageImpl<Object[]> result = postRepository.getPostList(pageRequestDTO);
+
+        //then
+        assertThat(result.getTotalElements()).isEqualTo(12);
+        assertThat(result.getTotalPages()).isEqualTo(2);
+        for (Object[] objects : result) {
+//            System.out.println(Arrays.toString(objects));
+        }
     }
 }


### PR DESCRIPTION
페이징 처리 및 검색 관련 기능 추가했습니다.
정상적으로 동작은 해서 일단 올리는데 수정할 부분은 얘기하면서 진행하는게 효율적일 것 같아요

## PageImpl<Object[]> getPostList(PageRequestDTO pageRequestDTO)
- 해당 메서드가 페이징 처리를 위해 최초로 호출됩니다. 반환부에 Object[]는 DTO로 변환처리할 예정입니다.
변환을 repository 단에서 할지 service 단에서 할지 의견 공유 부탁드려요 
https://doing7.tistory.com/129 해당 링크는 변환 관련 방법들이 정리되어 있어서 살펴 보시면 좋을 것 같습니다.

- 메서드 내부를 보시면 커버링 인덱싱 방법을 적용해서 한번에 처리하진 못해서 깔끔해 보이진 않는 것 같아요
보통 DB 처리 시간을 결정하는 것이 데이터 블록에 얼마나 접근하는지에 의해 결정된다고 합니다. 데이터 블록에 접근 횟수를 줄이고자 최초에는 조건에 맞는 id 값만 가져와 리스트에 저장하고 해당 리스트에 있는 값들을 최종적으로 가져오게 했습니다.
https://jojoldu.tistory.com/529?category=637935 해당 블로그 글을 참고했고 커버링 인덱스에 대해선 저도 더 공부해야 할 것 같아요

- 검색 부분도 조금 더 나은 방법이 없는지 고민해봐야할 것 같은데요, 현재는 request에서 title에 해당하는 t, content에 해당하는 c를 받아서 존재하면 keyword가 있는지 여부를 확인하는 방법으로 구현했습니다.

ENUM을 잘 활용하면  가독성 좋은 코드를 쓸 수 있을 것 같은데,, 관련 링크 남길게요
https://techblog.woowahan.com/2527/
https://velog.io/@recordsbeat/Enum%EA%B3%BC-Function%EC%9D%84-%EC%82%AC%EC%9A%A9%ED%95%98%EC%97%AC-QueryDSL-Keyword%EA%B2%80%EC%83%89-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0

추가로 
- pageRequestDTO, pageResponseDTO 내부 필드 추가, 삭제 
- postRepositoryImpl 내 검색 관련 메서드 별도 클래스 분리
- 페이징 처리 후 보여질 항목( post의 제목,내용,카페 이름 등등) 결정
정도 고민해봐야 할 것 같습니다