### PR TITLE
refactor, feat : pagination and search 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 
     // log4j2
     implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+
+    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 def querydslDir = "$buildDir/generated/querydsl"

--- a/src/main/java/com/sanhak/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/sanhak/backend/domain/post/controller/PostController.java
@@ -18,10 +18,11 @@ public class PostController {
     @GetMapping("/")
     public Page<PostDTO> findByPagination(
             @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @RequestParam(value = "size", defaultValue = "10") Integer size
+            @RequestParam(value = "size", defaultValue = "10") Integer size,
+            @RequestParam(value = "title", defaultValue = "") String title
     ) {
         PageRequest pr = PageRequest.of(page, size);
-        return postService.findByPagination(pr);
+        return postService.findByPagination(pr, title);
     }
 
     @GetMapping("/detail/{id}")

--- a/src/main/java/com/sanhak/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/sanhak/backend/domain/post/controller/PostController.java
@@ -5,11 +5,8 @@ import com.sanhak.backend.domain.post.dto.PostDetailDTO;
 import com.sanhak.backend.domain.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/post")
@@ -18,14 +15,17 @@ public class PostController {
 
     private final PostService postService;
 
-    // pagination
     @GetMapping("/")
-    public Page<PostDTO> findByPagination(Pageable pageable){
-        return postService.findByPagination(pageable);
+    public Page<PostDTO> findByPagination(
+            @RequestParam(value = "page", defaultValue = "0") Integer page,
+            @RequestParam(value = "size", defaultValue = "10") Integer size
+    ) {
+        PageRequest pr = PageRequest.of(page, size);
+        return postService.findByPagination(pr);
     }
 
     @GetMapping("/detail/{id}")
-    public PostDetailDTO findById(@PathVariable("id") Long id){
+    public PostDetailDTO findById(@PathVariable("id") Long id) {
         return postService.findPostDetailByPostId(id);
     }
 

--- a/src/main/java/com/sanhak/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/sanhak/backend/domain/post/controller/PostController.java
@@ -2,10 +2,12 @@ package com.sanhak.backend.domain.post.controller;
 
 import com.sanhak.backend.domain.post.dto.PostDTO;
 import com.sanhak.backend.domain.post.dto.PostDetailDTO;
+import com.sanhak.backend.domain.post.dto.PostSearch;
 import com.sanhak.backend.domain.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -17,12 +19,10 @@ public class PostController {
 
     @GetMapping("/")
     public Page<PostDTO> findByPagination(
-            @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @RequestParam(value = "size", defaultValue = "10") Integer size,
-            @RequestParam(value = "title", defaultValue = "") String title
+            @Validated @RequestBody
+            PostSearch postSearch
     ) {
-        PageRequest pr = PageRequest.of(page, size);
-        return postService.findByPagination(pr, title);
+        return postService.findByPagination(postSearch);
     }
 
     @GetMapping("/detail/{id}")

--- a/src/main/java/com/sanhak/backend/domain/post/dto/PostDTO.java
+++ b/src/main/java/com/sanhak/backend/domain/post/dto/PostDTO.java
@@ -1,4 +1,16 @@
 package com.sanhak.backend.domain.post.dto;
 
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
 public class PostDTO {
+    private String cafeName;
+    private String categoryName;
+    private String title;
+    private String author;
+    private String content;
+    private LocalDateTime registerAt;
+    private String link;
+    private Double similarity;
 }

--- a/src/main/java/com/sanhak/backend/domain/post/dto/PostSearch.java
+++ b/src/main/java/com/sanhak/backend/domain/post/dto/PostSearch.java
@@ -1,5 +1,6 @@
 package com.sanhak.backend.domain.post.dto;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -50,4 +51,14 @@ public class PostSearch {
         return content + "%";
     }
 
+    @Builder
+    public PostSearch(Integer page, Integer size, String cafeName, String categoryName, String title, String author, LocalDateTime registerAt) {
+        this.page = page;
+        this.size = size;
+        this.cafeName = cafeName;
+        this.categoryName = categoryName;
+        this.title = title;
+        this.author = author;
+        this.registerAt = registerAt;
+    }
 }

--- a/src/main/java/com/sanhak/backend/domain/post/dto/PostSearch.java
+++ b/src/main/java/com/sanhak/backend/domain/post/dto/PostSearch.java
@@ -1,0 +1,53 @@
+package com.sanhak.backend.domain.post.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Min;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Data
+@NoArgsConstructor
+public class PostSearch {
+    // 필수
+    @Min(value = 0L)
+    private Integer page;
+    @Min(value = 1L)
+    private Integer size;
+    // 선택
+    private String cafeName;
+    private String categoryName;
+    private String title;
+    private String author;
+    private LocalDateTime registerAt;
+
+    public Integer getPage() {
+        return page == null ? 0 : page;
+    }
+
+    public Integer getSize() {
+        return size == null ? 10 : size;
+    }
+
+    public String getTitleRegex() {
+        return title == null ? null : convertRegex(title);
+    }
+
+    public String getCafeNameRegex() {
+        return cafeName == null ? null : convertRegex(cafeName);
+    }
+
+    public String getCategoryNameRegex() {
+        return categoryName == null ? null : convertRegex(categoryName);
+    }
+
+    public String getAuthorRegex() {
+        return author == null ? null : convertRegex(author);
+    }
+
+    private String convertRegex(String content) {
+        return content + "%";
+    }
+
+}

--- a/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.sanhak.backend.domain.post.repository;
 
 import com.sanhak.backend.domain.post.Post;
+import com.sanhak.backend.domain.post.dto.PostSearch;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -8,5 +9,5 @@ import java.util.Optional;
 
 public interface PostRepositoryCustom {
     Optional<Post> findPostDetailByPostId(Long id);
-    Page<Post> findByPaginationWithQuerydsl(Pageable pageable, String title);
+    Page<Post> findByPaginationWithQuerydsl(PostSearch postSearch);
 }

--- a/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryCustom.java
@@ -1,9 +1,12 @@
 package com.sanhak.backend.domain.post.repository;
 
 import com.sanhak.backend.domain.post.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
 public interface PostRepositoryCustom {
     Optional<Post> findPostDetailByPostId(Long id);
+    Page<Post> findByPaginationWithQuerydsl(Pageable pageable, String title);
 }

--- a/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryCustom.java
@@ -3,11 +3,10 @@ package com.sanhak.backend.domain.post.repository;
 import com.sanhak.backend.domain.post.Post;
 import com.sanhak.backend.domain.post.dto.PostSearch;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+
 
 import java.util.Optional;
 
 public interface PostRepositoryCustom {
     Optional<Post> findPostDetailByPostId(Long id);
-    Page<Post> findByPaginationWithQuerydsl(PostSearch postSearch);
-}
+    Page<Post> findByPaginationWithQuerydsl(PostSearch postSearch);}

--- a/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryImpl.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
-
 import static com.sanhak.backend.domain.comment.QComment.comment;
 import static com.sanhak.backend.domain.post.QPost.post;
 

--- a/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryImpl.java
@@ -1,12 +1,15 @@
 package com.sanhak.backend.domain.post.repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sanhak.backend.domain.post.Post;
+import com.sanhak.backend.domain.post.dto.PostSearch;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
 
@@ -43,18 +46,54 @@ public class PostRepositoryImpl extends QuerydslRepositorySupport implements Pos
     }
 
     @Override
-    public Page<Post> findByPaginationWithQuerydsl(Pageable pageable, String regex) {
+    public Page<Post> findByPaginationWithQuerydsl(PostSearch postSearch) {
+
+        PageRequest pageRequest = PageRequest.of(postSearch.getPage(), postSearch.getSize());
+
+        String titleRegex = postSearch.getTitleRegex();
+        String cafeNameRegex = postSearch.getCafeNameRegex();
+        String categoryNameRegex = postSearch.getCategoryNameRegex();
+        String authorRegex = postSearch.getAuthorRegex();
+
+
         JPAQuery<Post> query = jpaQueryFactory
                 .select(post)
                 .from(post)
-                .where(post.title.like(regex));
+                .where(likeTitle(titleRegex))
+                .where(likeCafeName(cafeNameRegex))
+                .where(likeCategoryName(categoryNameRegex))
+                .where(likeAuthor(authorRegex));
 
         Long fetchCount = jpaQueryFactory
                 .select(post.count())
                 .from(post)
-                .where(post.title.like(regex)).fetchOne();
+                .where(likeTitle(titleRegex))
+                .where(likeCafeName(cafeNameRegex))
+                .where(likeCategoryName(categoryNameRegex))
+                .where(likeAuthor(authorRegex))
+                .fetchOne();
 
-        List<Post> postList = this.getQuerydsl().applyPagination(pageable, query).fetch();
-        return new PageImpl<>(postList, pageable, fetchCount);
+        List<Post> postList = this.getQuerydsl().applyPagination(pageRequest, query).fetch();
+        return new PageImpl<>(postList, pageRequest, fetchCount);
+    }
+
+    private BooleanExpression likeTitle(String titleRegex) {
+        if (StringUtils.isNullOrEmpty(titleRegex)) return null;
+        return post.title.like(titleRegex);
+    }
+
+    private BooleanExpression likeCafeName(String cafeNameRegex) {
+        if (StringUtils.isNullOrEmpty(cafeNameRegex)) return null;
+        return post.cafeName.like(cafeNameRegex);
+    }
+
+    private BooleanExpression likeCategoryName(String categoryNameRegex) {
+        if (StringUtils.isNullOrEmpty(categoryNameRegex)) return null;
+        return post.categoryName.like(categoryNameRegex);
+    }
+
+    private BooleanExpression likeAuthor(String authorRegex) {
+        if (StringUtils.isNullOrEmpty(authorRegex)) return null;
+        return post.author.like(authorRegex);
     }
 }

--- a/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/sanhak/backend/domain/post/repository/PostRepositoryImpl.java
@@ -1,30 +1,60 @@
 package com.sanhak.backend.domain.post.repository;
 
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sanhak.backend.domain.post.Post;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 import java.util.Optional;
+
 import static com.sanhak.backend.domain.comment.QComment.comment;
 import static com.sanhak.backend.domain.post.QPost.post;
 
 
 @Repository
-@RequiredArgsConstructor
-public class PostRepositoryImpl implements PostRepositoryCustom{
+public class PostRepositoryImpl extends QuerydslRepositorySupport implements PostRepositoryCustom {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    @Override
-    public Optional<Post> findPostDetailByPostId(Long id){
+    @Autowired
+    public PostRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        super(Post.class);
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
 
-        Post result= jpaQueryFactory.select(post)
+    @Override
+    public Optional<Post> findPostDetailByPostId(Long id) {
+
+        Post result = jpaQueryFactory
+                .select(post)
                 .from(post)
-                .leftJoin(post.comment,comment)
+                .leftJoin(post.comment, comment)
                 .fetchJoin()
                 .where(post.id.eq(id))
                 .fetchOne();
 
         return Optional.ofNullable(result);
+    }
+
+    @Override
+    public Page<Post> findByPaginationWithQuerydsl(Pageable pageable, String regex) {
+        JPAQuery<Post> query = jpaQueryFactory
+                .select(post)
+                .from(post)
+                .where(post.title.like(regex));
+
+        Long fetchCount = jpaQueryFactory
+                .select(post.count())
+                .from(post)
+                .where(post.title.like(regex)).fetchOne();
+
+        List<Post> postList = this.getQuerydsl().applyPagination(pageable, query).fetch();
+        return new PageImpl<>(postList, pageable, fetchCount);
     }
 }

--- a/src/main/java/com/sanhak/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/sanhak/backend/domain/post/service/PostService.java
@@ -3,6 +3,7 @@ package com.sanhak.backend.domain.post.service;
 import com.sanhak.backend.domain.post.Post;
 import com.sanhak.backend.domain.post.dto.PostDTO;
 import com.sanhak.backend.domain.post.dto.PostDetailDTO;
+import com.sanhak.backend.domain.post.dto.PostSearch;
 import com.sanhak.backend.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -18,9 +19,9 @@ public class PostService {
     private final PostRepository postRepository;
     private final ModelMapper modelMapper;
 
-    public Page<PostDTO> findByPagination(Pageable pageable, String title) {
+    public Page<PostDTO> findByPagination(PostSearch postSearch) {
         return postRepository
-                .findByPaginationWithQuerydsl(pageable, title + "%")
+                .findByPaginationWithQuerydsl(postSearch)
                 .map(post -> modelMapper.map(post, PostDTO.class));
     }
 

--- a/src/main/java/com/sanhak/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/sanhak/backend/domain/post/service/PostService.java
@@ -18,9 +18,9 @@ public class PostService {
     private final PostRepository postRepository;
     private final ModelMapper modelMapper;
 
-    public Page<PostDTO> findByPagination(Pageable pageable) {
+    public Page<PostDTO> findByPagination(Pageable pageable, String title) {
         return postRepository
-                .findAll(pageable)
+                .findByPaginationWithQuerydsl(pageable, title + "%")
                 .map(post -> modelMapper.map(post, PostDTO.class));
     }
 

--- a/src/test/java/com/sanhak/backend/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/sanhak/backend/domain/post/repository/PostRepositoryTest.java
@@ -3,30 +3,21 @@ package com.sanhak.backend.domain.post.repository;
 import com.sanhak.backend.domain.comment.Comment;
 import com.sanhak.backend.domain.comment.repository.CommentRepository;
 import com.sanhak.backend.domain.post.Post;
+import com.sanhak.backend.domain.post.dto.PostSearch;
 import com.sanhak.backend.global.QuerydslConfig;
-import org.aspectj.lang.annotation.Before;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.*;
-
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
 import org.springframework.test.context.ActiveProfiles;
 
-
-import javax.persistence.EntityManager;
-import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-
-
 
 @DataJpaTest
 @ActiveProfiles("test")
@@ -39,7 +30,7 @@ class PostRepositoryTest {
     private CommentRepository commentRepository;
 
     @BeforeAll
-    public void init(){
+    public void init() {
         Post post = Post.builder()
                 .id(1L)
                 .cafeName("cafe1")
@@ -54,8 +45,8 @@ class PostRepositoryTest {
 
         postRepository.save(post);
 
-        IntStream.rangeClosed(1,5)
-                .forEach(i->{
+        IntStream.rangeClosed(1, 5)
+                .forEach(i -> {
                     Comment comment = Comment.builder()
                             .content("content.." + i)
                             .post(Post.builder().id(1L).build())
@@ -67,30 +58,58 @@ class PostRepositoryTest {
     @Test
     @DisplayName("postId로 검색_해당 포스트가 있는 경우")
     void findPostDetailByPostId_exist() {
-        Long postId= 1L;
+        Long postId = 1L;
 
         Optional<Post> result = postRepository.findPostDetailByPostId(postId);
 
         assertThat(result.isPresent()).isEqualTo(true);
         Post post = result.get();
         List<Comment> comments = post.getComment();
-        for(int i=0;i<comments.size();i++){
-            assertThat(comments.get(i).getId()).isEqualTo(i+1);
-            assertThat(comments.get(i).getContent()).isEqualTo("content.."+(i+1));
+        for (int i = 0; i < comments.size(); i++) {
+            assertThat(comments.get(i).getId()).isEqualTo(i + 1);
+            assertThat(comments.get(i).getContent()).isEqualTo("content.." + (i + 1));
         }
-
-
-
     }
 
     @Test
     @DisplayName("postId로 검색_해당 포스트가 없는 경우")
-    public void findPostDetailByPostId_notExist() throws Exception{
+    public void findPostDetailByPostId_notExist() throws Exception {
         //give
-        Long postId=0L;
+        Long postId = 0L;
         //when
         Optional<Post> result = postRepository.findPostDetailByPostId(postId);
         assertThat(result.isPresent()).isEqualTo(false);
         //then
+    }
+
+    @Test
+    @DisplayName("pagination : 여러 파라미터를 이용해서 검색을 해도 괜찮은지 검증")
+    void findByPaginationAndSearch() throws Exception {
+        //given
+        String cafeName = "cafe1";
+        String categoryName = "category1";
+        String title = "title1";
+        String author = "author1";
+
+        PostSearch postSearchJustCafeName = PostSearch.builder()
+                .cafeName(cafeName).build();
+        PostSearch postSearchJustCategoryName = PostSearch.builder()
+                .categoryName(categoryName).build();
+        PostSearch postSearchJustTitle = PostSearch.builder()
+                .title(title).build();
+        PostSearch postSearchJustAuthor = PostSearch.builder()
+                .author(author).build();
+
+        //when
+        Page<Post> resultByCafeName = postRepository.findByPaginationWithQuerydsl(postSearchJustCafeName);
+        Page<Post> resultByCategoryName = postRepository.findByPaginationWithQuerydsl(postSearchJustCategoryName);
+        Page<Post> resultByTitle = postRepository.findByPaginationWithQuerydsl(postSearchJustTitle);
+        Page<Post> resultByAuthor = postRepository.findByPaginationWithQuerydsl(postSearchJustAuthor);
+
+        //then
+        assertThat(resultByCafeName.getTotalElements()).isEqualTo(1L);
+        assertThat(resultByCategoryName.getTotalElements()).isEqualTo(1L);
+        assertThat(resultByTitle.getTotalElements()).isEqualTo(1L);
+        assertThat(resultByAuthor.getTotalElements()).isEqualTo(1L);
     }
 }


### PR DESCRIPTION
## 추가 기능
1. pagination이 정상 작동할 수 있도록 수정
2. pagination과  search 기능이 동시에 동작할 수 있도록 구현(with querydsl)
-  검색 기능은 현재 post title만 검색 가능하도록 구현하였고 만약 ["제목1", "제목2","제목3"]이렇게 post가 있다면 "제" or "제목"으로 검색할 수 있도록 regex 지정하였습니다.
-  (추가)검색 기능을 좀 더 자유롭게 사용할 수 있도록 변경하였습니다.  제목 뿐만 아니라 cafeName, cateogoryName, title, author를 이용해서 검색할 수 있도록 수정하였고 4개의 필드 중 일부만 사용해도 정상적으로 작동하도록 구현하였습니다.
3. pagination, search에 관한 test code 추가